### PR TITLE
Feature/navbar animation fix

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -22,16 +22,16 @@
       >
         <ul class="navbar-nav ml-auto">
           <li class="nav-item">
-            <a class="nav-link" data-toggle="collapse" data-target="#navbarCollapse" routerLink="/home">Home</a>
+            <a class="nav-link" (click)="toggleCollapsed()" routerLink="/home">Home</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" data-toggle="collapse" data-target="#navbarCollapse" routerLink="/about">Over ons</a>
+            <a class="nav-link" (click)="toggleCollapsed()" routerLink="/about">Over ons</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" data-toggle="collapse" data-target="#navbarCollapse" routerLink="/faq">FAQ</a>
+            <a class="nav-link" (click)="toggleCollapsed()" routerLink="/faq">FAQ</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" data-toggle="collapse" data-target="#navbarCollapse" routerLink="/partner">Partners</a>
+            <a class="nav-link" (click)="toggleCollapsed()" routerLink="/partner">Partners</a>
           </li>
         </ul>
       </div>

--- a/src/app/components/navbar/navbar.component.spec.ts
+++ b/src/app/components/navbar/navbar.component.spec.ts
@@ -37,6 +37,7 @@ describe('NavbarComponent', () => {
 
     router = TestBed.inject(Router);
     mockHttpClient = TestBed.inject(HttpTestingController);
+    document.documentElement.style.width = '700px';
 
     fixture.detectChanges();
   });
@@ -80,5 +81,24 @@ describe('NavbarComponent', () => {
     await fixture.whenRenderingDone();
 
     expect(collapsableContent.classList.contains('show')).toBe(false);
+  });
+
+  it('should not toggle collapsed when document is to wide to be toggleable.', () => {
+    const collapseBtn: HTMLButtonElement = element.querySelector('button.navbar-toggler');
+    const faqLink: HTMLAnchorElement = element.querySelector(`a[routerLink='/faq']`);
+    const collapsableContent: HTMLElement = element.querySelector('#navbarCollapse');
+    const toggleCollapsedSpy = spyOn(component, 'toggleCollapsed');
+
+    document.documentElement.style.width = '800px';
+    fixture.detectChanges();
+
+    expect(toggleCollapsedSpy).not.toHaveBeenCalled();
+    expect(collapsableContent.classList.contains('collapse')).toBe(true);
+
+    faqLink.click();
+    fixture.detectChanges();
+
+    expect(toggleCollapsedSpy).toHaveBeenCalled();
+    expect(collapsableContent.classList.contains('collapse')).toBe(true);
   });
 });

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -64,6 +64,13 @@ export class NavbarComponent implements OnInit, OnDestroy {
   }
 
   toggleCollapsed(): void {
+    const documentWithStyle = window.getComputedStyle(document.documentElement).width;
+    const documentWith = parseInt(documentWithStyle.replace('px', ''));
+
+    if (documentWith >= 768) {
+      this.collapsed = true;
+      return;
+    }
     this.collapsed = !this.collapsed;
   }
 

--- a/tslint.json
+++ b/tslint.json
@@ -157,6 +157,7 @@
       "app",
       "kebab-case"
     ],
-    "forin": false
+    "forin": false,
+    "radix": false
   }
 }


### PR DESCRIPTION
Fixed a bug where the header animation would still trigger when the collapse and show states where no longer necessary. (when the window with was to large for the collapsible part to be able to collapse, for example.)

The tests will show that the implemented part is not fully covered yet, I'll try to tackle that after the demo is done tomorrow.